### PR TITLE
Update Circle CI Contexts to Correct Name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,13 +435,13 @@ workflows:
     jobs:
       - build-to-ecr:
           <<: *main-only
-          context: laa-claim-non-standard-magistrates-fee-dev
+          context: laa-apply-for-a-criminal-legal-aid-application-dev
       - hold-dev:
           type: approval
           requires:
             - build-to-ecr
       - deploy-dev:
-          context: laa-claim-non-standard-magistrates-fee-dev
+          context: laa-apply-for-a-criminal-legal-aid-application-dev
           requires:
             - hold-dev
       - hold-dev-crm4:


### PR DESCRIPTION
## Description of change

 [DEV - Setup New Kubernetes Namespaces for Provider App](https://dsdmoj.atlassian.net/browse/CRM457-940)

This allows a push to dev with the new repo name, other environments are pending
