### PR TITLE
CRM457-978: Make date of next hearing optional

### DIFF
--- a/app/forms/prior_authority/steps/hearing_detail_form.rb
+++ b/app/forms/prior_authority/steps/hearing_detail_form.rb
@@ -5,7 +5,7 @@ module PriorAuthority
       attribute :plea, :value_object, source: PleaOptions
       attribute :court_type, :value_object, source: CourtTypeOptions
 
-      validates :next_hearing_date, presence: true, multiparam_date: { allow_past: true, allow_future: true }
+      validates :next_hearing_date, multiparam_date: { allow_past: true, allow_future: true }
       validates :plea, inclusion: { in: PleaOptions.values }
       validates :court_type, inclusion: { in: CourtTypeOptions.values }
 

--- a/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
       it { is_expected.to be_valid }
     end
 
+    context 'without next hearing date' do
+      let(:hearing_detail_attributes) do
+        {
+          next_hearing_date: nil,
+          plea: 'not_guilty',
+          court_type: 'central_criminal_court',
+        }
+      end
+
+      it { is_expected.to be_valid }
+    end
+
     context 'with invalid hearing details' do
       let(:hearing_detail_attributes) do
         {
@@ -34,11 +46,10 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
         }
       end
 
-      it 'has a validation error on the field' do
+      it 'has expected validation errors on the field' do
         expect(form).not_to be_valid
         expect(form.errors.messages.values.flatten)
-          .to include('Date cannot be blank',
-                      'Select the likely or actual plea',
+          .to include('Select the likely or actual plea',
                       'Select the type of court')
       end
     end

--- a/spec/system/prior_authority/hearing_details_spec.rb
+++ b/spec/system/prior_authority/hearing_details_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Prior authority applications - add hearing details' do
   it 'validates hearing detail fields' do
     click_on 'Save and continue'
     expect(page)
-      .to have_content('Date cannot be blank')
+      .to have_no_content('Date cannot be blank')
       .and have_content('Select the likely or actual plea')
       .and have_content('Select the type of court')
   end


### PR DESCRIPTION

## Description of change
Make date o fnext hearing optional

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-978)

For non-prison law matters the date of next hearing
does not need to be provided.

Raised during QA as missing.
